### PR TITLE
added instructions for writing prompt selection

### DIFF
--- a/src/components/writingPromptsGallery/Gallery.js
+++ b/src/components/writingPromptsGallery/Gallery.js
@@ -2,6 +2,7 @@
 // Docs: https://mui.com/material-ui/api/grid/
 
 import React from 'react';
+import Instructions from './Instructions';
 import Grid from '@mui/material/Grid';
 import WritingOptionCard from '../WritingOptionCard';
 import './Gallery.css'
@@ -25,6 +26,8 @@ function Gallery() {
     const countryPrompt = country[Math.floor(Math.random()*country.length)]
 
     return ( 
+        <>
+        <Instructions />
         <Grid container spacing={2}>
             <Grid item xs={4} md={4}>
                 <div className="gridspace">
@@ -75,6 +78,7 @@ function Gallery() {
                 </div>
             </Grid>
         </Grid>
+    </>
     );
 }
 

--- a/src/components/writingPromptsGallery/Instructions.js
+++ b/src/components/writingPromptsGallery/Instructions.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+
+
+function Instructions() {
+    return ( 
+        <div className="instruct-div">
+            <p className="instructions"> 
+            Your prompts will be a random word or phrase from each category you choose. 
+            <br />
+            Generate your prompts by clicking the categories! </p>
+        </div>
+    );
+}
+
+export default Instructions;


### PR DESCRIPTION
instructions should render on page above grid, will be constant - stays on page even if user has selected all prompts.